### PR TITLE
Fix regex to validate linux file paths

### DIFF
--- a/src/septentrio_gnss_driver/node/rosaic_node.cpp
+++ b/src/septentrio_gnss_driver/node/rosaic_node.cpp
@@ -475,7 +475,7 @@ void rosaic_node::ROSaicNode::initializeIO()
 		boost::thread temporary_thread(boost::bind(&ROSaicNode::connect, this));
 		temporary_thread.detach();
 	}
-	else if (boost::regex_match(device_, match, boost::regex("(file_name):(\\w+.sbf)")))
+	else if (boost::regex_match(device_, match, boost::regex("(file_name):(/|(?:/[\\w-]+)+.sbf)")))
 	{
 		serial_ = false;
 		g_read_from_sbf_log = true;


### PR DESCRIPTION
Fix Issue - https://github.com/septentrio-gnss/septentrio_gnss_driver/issues/34