### PR TITLE
[FEATURE] Compatibility with PCAP files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ find_package(catkin REQUIRED COMPONENTS
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS system thread regex)
 
+find_library(libpcap_LIBRARIES pcap)
+if ("${libpcap_LIBRARIES}" STREQUAL "pcap-NOTFOUND")
+    set(libpcap_FOUND FALSE)
+else ()
+    set(libpcap_FOUND TRUE)
+endif ()
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -150,7 +156,21 @@ include_directories(
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
-add_executable(${PROJECT_NAME}_node src/septentrio_gnss_driver/node/rosaic_node.cpp src/septentrio_gnss_driver/communication/circular_buffer.cpp src/septentrio_gnss_driver/parsers/parsing_utilities.cpp src/septentrio_gnss_driver/parsers/string_utilities.cpp src/septentrio_gnss_driver/parsers/nmea_parsers/gpgga.cpp src/septentrio_gnss_driver/parsers/nmea_parsers/gprmc.cpp src/septentrio_gnss_driver/parsers/nmea_parsers/gpgsa.cpp src/septentrio_gnss_driver/parsers/nmea_parsers/gpgsv.cpp src/septentrio_gnss_driver/crc/crc.c src/septentrio_gnss_driver/communication/communication_core.cpp src/septentrio_gnss_driver/communication/rx_message.cpp src/septentrio_gnss_driver/communication/callback_handlers.cpp)
+add_executable(${PROJECT_NAME}_node 
+    src/septentrio_gnss_driver/node/rosaic_node.cpp 
+    src/septentrio_gnss_driver/communication/circular_buffer.cpp 
+    src/septentrio_gnss_driver/parsers/parsing_utilities.cpp 
+    src/septentrio_gnss_driver/parsers/string_utilities.cpp 
+    src/septentrio_gnss_driver/parsers/nmea_parsers/gpgga.cpp 
+    src/septentrio_gnss_driver/parsers/nmea_parsers/gprmc.cpp 
+    src/septentrio_gnss_driver/parsers/nmea_parsers/gpgsa.cpp 
+    src/septentrio_gnss_driver/parsers/nmea_parsers/gpgsv.cpp 
+    src/septentrio_gnss_driver/crc/crc.c 
+    src/septentrio_gnss_driver/communication/communication_core.cpp 
+    src/septentrio_gnss_driver/communication/rx_message.cpp 
+    src/septentrio_gnss_driver/communication/callback_handlers.cpp
+    src/septentrio_gnss_driver/communication/pcap_reader.cpp
+)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -164,7 +184,7 @@ add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catk
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}_node 
-   ${catkin_LIBRARIES} ${Boost_LIBRARIES}
+   ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${libpcap_LIBRARIES}
 )
 
 #############

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Please [let the maintainers know](mailto:githubuser@septentrio.com?subject=[GitH
 The `master` branch for this driver functions on both ROS Melodic (Ubuntu 18.04) and Noetic (Ubuntu 20.04). It is thus necessary to [install](https://wiki.ros.org/Installation/Ubuntu) the ROS version that has been designed for your Linux distro.<br><br>
 The serial and TCP/IP communication interface of the ROS driver is established by means of the [Boost C++ library](https://www.boost.org/). In the unlikely event that the below installation instructions fail to install Boost on the fly, please install the Boost libraries via<br><br>
 `sudo apt install libboost-all-dev`.<br><br>
+Compatiblity with PCAP captures are incorporate through [pcap libraries](https://github.com/the-tcpdump-group/libpcap). Install the same via<br><br>
+`sudo apt install libpcap-dev`.<br><br>
 
 ## Usage
 The binary release is now available for Melodic, yet will take another few days for Noetic. To install the binary package on Melodic, simply run<br><br>
@@ -116,6 +118,7 @@ The following is a list of ROSaic parameters found in the `config/rover.yaml` fi
   - `device`: location of device connection
     - `serial:xxx` format for serial connections, where `xxx` is the device node, e.g. `serial:/dev/ttyUSB0`
     - `file_name:path/to/file.sbf` format for publishing from an SBF log
+    - `file_name:path/to/file.pcap` format for publishing from PCAP capture.
       - Regarding the file path, ROS_HOME=\`pwd\` in front of `roslaunch septentrio...` might be useful to specify that the node should be started using the executable's directory as its working-directory.
     - `tcp://host:port` format for TCP/IP connections
       - `28784` should be used as the default (command) port for TCP/IP connections. If another port is specified, the receiver needs to be (re-)configured via the Web Interface before ROSaic can be used.
@@ -206,7 +209,6 @@ A selection of NMEA sentences, the majority being standardized sentences, and pr
 
 ## Suggestions for Improvements
 - Automatic Search: If the host address of the receiver is omitted in the `host:port` specification, the driver could automatically search and establish a connection on the specified port.
-- Incorporating PCAP: For PCAP connections the ROS parameter `device` could be generalized to accept the path to the .pcap file. In this case, the node could exit automatically after finishing playback.
 - Publishing the topic `/measepoch`: It could accept the custom ROS message `septentrio_gnss_driver/MeasEpoch.msg`, corresponding to the SBF block `MeasEpoch` (raw GNSS data).
 - Publishing the topic `/twist`: It could accept the generic ROS message [`geometry_msgs/TwistWithCovarianceStamped.msg`](https://docs.ros.org/melodic/api/geometry_msgs/html/msg/TwistWithCovarianceStamped.html), converted from the SBF blocks `PVTGeodetic`, `PosCovGeodetic` and others or via standardized NMEA sentences (cf. the [NMEA driver](https://wiki.ros.org/nmea_navsat_driver)).
   - The ROS message [`geometry_msgs/TwistWithCovarianceStamped.msg`](https://docs.ros.org/melodic/api/geometry_msgs/html/msg/TwistWithCovarianceStamped.html) could be fed directly into the [`robot_localization`](https://docs.ros.org/melodic/api/robot_localization/html/index.html) nodes of the ROS navigation stack.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please [let the maintainers know](mailto:githubuser@septentrio.com?subject=[GitH
 The `master` branch for this driver functions on both ROS Melodic (Ubuntu 18.04) and Noetic (Ubuntu 20.04). It is thus necessary to [install](https://wiki.ros.org/Installation/Ubuntu) the ROS version that has been designed for your Linux distro.<br><br>
 The serial and TCP/IP communication interface of the ROS driver is established by means of the [Boost C++ library](https://www.boost.org/). In the unlikely event that the below installation instructions fail to install Boost on the fly, please install the Boost libraries via<br><br>
 `sudo apt install libboost-all-dev`.<br><br>
-Compatiblity with PCAP captures are incorporate through [pcap libraries](https://github.com/the-tcpdump-group/libpcap). Install the same via<br><br>
+Compatiblity with PCAP captures are incorporated through [pcap libraries](https://github.com/the-tcpdump-group/libpcap). Install the necessary headers via<br><br>
 `sudo apt install libpcap-dev`.<br><br>
 
 ## Usage

--- a/include/septentrio_gnss_driver/communication/communication_core.hpp
+++ b/include/septentrio_gnss_driver/communication/communication_core.hpp
@@ -142,6 +142,14 @@ namespace io_comm_rx {
          * @param[in] file_name The name of (or path to) the SBF file, e.g. "xyz.sbf"
          */
         void initializeSBFFileReading(std::string file_name);
+
+        /**
+         * @brief Initializes PCAP file reading and reads PCAP file by repeatedly
+         * calling read_callback_()
+         * @param[in] file_name The name of (or path to) the PCAP file, e.g. "/tmp/capture.pcap"
+         */
+        void initializePCAPFileReading(std::string file_name);
+
         /**
          * @brief Set the I/O manager
          * @param[in] manager An I/O handler

--- a/include/septentrio_gnss_driver/communication/pcap_reader.hpp
+++ b/include/septentrio_gnss_driver/communication/pcap_reader.hpp
@@ -1,0 +1,118 @@
+// *****************************************************************************
+//
+// © Copyright 2020, Septentrio NV/SA.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//    1. Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//    2. Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//    3. Neither the name of the copyright holder nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef PCAP_READER_H
+#define PCAP_READER_H
+
+#include <pcap/pcap.h>
+#include <stdint.h>
+#include <vector>
+
+/**
+ * @file pcap_reader.hpp
+ * @date 07/05/2021
+ * @author Ashwin A Nayar
+ *
+ * @brief Declares a class for handling pcap files.
+ */
+
+namespace pcapReader {
+
+    using buffer_t = std::vector<uint8_t>;
+
+    //! Read operation status
+    enum ReadResult
+    {
+        /// Data read successfully
+        READ_SUCCESS = 0,
+        READ_INSUFFICIENT_DATA = 1,
+        READ_TIMEOUT = 2,
+        READ_INTERRUPTED = 3,
+        READ_ERROR = -1,
+        /// Unable to parse data, parsing error
+        READ_PARSE_FAILED = -2
+
+    };
+
+    /**
+     * @class PcapDevice
+     * @brief Class for handling a pcap file
+     */
+    class PcapDevice
+    {
+    public:
+        static const size_t BUFFSIZE = 100;
+
+        /**
+         * @brief Constructor for PcapDevice
+         * @param[out] buffer Buffer to write read raw data to
+         */
+        explicit PcapDevice(buffer_t& buffer);
+
+        /**
+         * @brief Try to open a pcap file
+         * @param[in] device Path to pcap file
+         * @return True if success, false otherwise
+         */
+        bool connect(const char* device);
+
+        /**
+         * @brief Close connected file
+         */
+        void disconnect();
+
+        /**
+         * @brief Check if file is open and healthy
+         * @return True if file is open, false otherwise
+         */
+        bool isConnected() const;
+
+        /**
+         * @brief Attempt to read a packet and store data to buffer
+         * @return Result of read operation
+         */
+        ReadResult read();
+
+        //! Destructor for PcapDevice
+        ~PcapDevice();
+
+    private:
+        //! Reference to raw data buffer to write to
+        buffer_t& m_dataBuff;
+        //! File handle to pcap file
+        pcap_t* m_device{nullptr};
+        bpf_program m_pktFilter{};
+        char m_errBuff[BUFFSIZE]{};
+        char* m_deviceName;
+        buffer_t m_lastPkt;
+    };
+} // namespace pcapReader
+
+#endif // PCAP_READER_H

--- a/include/septentrio_gnss_driver/communication/rx_message.hpp
+++ b/include/septentrio_gnss_driver/communication/rx_message.hpp
@@ -172,6 +172,7 @@ extern boost::shared_ptr<ros::NodeHandle> g_nh;
 extern const uint32_t g_ROS_QUEUE_SIZE;
 extern ros::Time g_unix_time;
 extern bool g_read_from_sbf_log;
+extern bool g_read_from_pcap_log;
 
 //! Enum for NavSatFix's status.status field, which is obtained from PVTGeodetic's
 //! Mode field

--- a/include/septentrio_gnss_driver/node/rosaic_node.hpp
+++ b/include/septentrio_gnss_driver/node/rosaic_node.hpp
@@ -220,6 +220,12 @@ namespace rosaic_node {
         void prepareSBFFileReading(std::string file_name);
 
         /**
+         * @brief Sets up the stage for PCAP file reading
+         * @param[in] file_name The path to PCAP file, e.g. "/tmp/capture.sbf"
+         */
+        void preparePCAPFileReading(std::string file_name);
+
+        /**
          * @brief Attempts to (re)connect every reconnect_delay_s_ seconds
          */
         void reconnect(const ros::TimerEvent& event);

--- a/package.xml
+++ b/package.xml
@@ -55,7 +55,7 @@
   <depend>geometry_msgs</depend>
   <depend>gps_common</depend>
   <depend>boost</depend>
-  <depend>pcap</depend>
+  <depend>libpcap</depend>
    
 
   <build_depend>cpp_common</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -55,6 +55,7 @@
   <depend>geometry_msgs</depend>
   <depend>gps_common</depend>
   <depend>boost</depend>
+  <depend>pcap</depend>
    
 
   <build_depend>cpp_common</build_depend>

--- a/src/septentrio_gnss_driver/communication/communication_core.cpp
+++ b/src/septentrio_gnss_driver/communication/communication_core.cpp
@@ -29,6 +29,7 @@
 // *****************************************************************************
 
 #include <septentrio_gnss_driver/communication/communication_core.hpp>
+#include <septentrio_gnss_driver/communication/pcap_reader.hpp>
 
 /**
  * @file communication_core.cpp
@@ -157,6 +158,58 @@ void io_comm_rx::Comm_IO::initializeSBFFileReading(std::string file_name)
     }
     delete[] to_be_parsed; // Freeing memory
     ROS_DEBUG("Leaving initializeSBFFileReading() method..");
+}
+
+void io_comm_rx::Comm_IO::initializePCAPFileReading(std::string file_name)
+{
+    ROS_DEBUG("Calling initializePCAPFileReading() method..");
+    pcapReader::buffer_t vec_buf;
+    pcapReader::PcapDevice device(vec_buf);
+
+    if (!device.connect(file_name.c_str()))
+    {
+        ROS_ERROR("Unable to find file or either it is corrupted");
+        return;
+    }
+
+    ROS_INFO("Reading ...");
+    while (device.isConnected() && device.read() == pcapReader::READ_SUCCESS)
+        ;
+    device.disconnect();
+
+    std::size_t buffer_size = pcapReader::PcapDevice::BUFFSIZE;
+    uint8_t* to_be_parsed = new uint8_t[buffer_size];
+    to_be_parsed = &vec_buf[0];
+
+    while (1) // Loop will stop if we are done reading the SBF file
+    {
+        try
+        {
+            ROS_DEBUG(
+                "Calling read_callback_() method, with number of bytes to be parsed being %li",
+                buffer_size);
+            handlers_.readCallback(to_be_parsed, buffer_size);
+        } catch (std::size_t& parsing_failed_here)
+        {
+            if (to_be_parsed - &vec_buf[0] >= vec_buf.size() * sizeof(uint8_t))
+            {
+                break;
+            }
+            if (!parsing_failed_here)
+                parsing_failed_here = 1;
+
+            to_be_parsed = to_be_parsed + parsing_failed_here;
+            ROS_DEBUG("Parsing_failed_here is %li", parsing_failed_here);
+            continue;
+        }
+        if (to_be_parsed - &vec_buf[0] >= vec_buf.size() * sizeof(uint8_t))
+        {
+            break;
+        }
+        to_be_parsed = to_be_parsed + buffer_size;
+    }
+    delete[] to_be_parsed;
+    ROS_DEBUG("Leaving initializePCAPFileReading() method..");
 }
 
 bool io_comm_rx::Comm_IO::initializeSerial(std::string port, uint32_t baudrate,

--- a/src/septentrio_gnss_driver/communication/pcap_reader.cpp
+++ b/src/septentrio_gnss_driver/communication/pcap_reader.cpp
@@ -1,0 +1,187 @@
+// *****************************************************************************
+//
+// © Copyright 2020, Septentrio NV/SA.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//    1. Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//    2. Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//    3. Neither the name of the copyright holder nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include "septentrio_gnss_driver/communication/pcap_reader.hpp"
+
+#include <chrono>
+#include <net/ethernet.h>
+#include <netinet/ip.h>
+#include <netinet/tcp.h>
+#include <ros/ros.h>
+#include <thread>
+
+/**
+ * @file pcap_reader.cpp
+ * @date 07/05/2021
+ * @author Ashwin A Nayar
+ *
+ * @brief Implements auxiliary reader object for handling pcap files.
+ *
+ * Functions include connecting to the file, reading the contents to the
+ * specified data buffer and graceful exit.
+ */
+
+namespace pcapReader {
+
+    PcapDevice::PcapDevice(buffer_t& buffer) : m_dataBuff{buffer} {}
+
+    PcapDevice::~PcapDevice() { disconnect(); }
+
+    bool PcapDevice::connect(const char* device)
+    {
+        if (isConnected())
+            return true;
+        // Try to open pcap file
+        if ((m_device = pcap_open_offline(device, m_errBuff)) == nullptr)
+            return false;
+
+        m_deviceName = (char*)device;
+        // Try to compile filter program
+        if (pcap_compile(m_device, &m_pktFilter, "tcp dst port 3001", 1,
+                         PCAP_NETMASK_UNKNOWN) != 0)
+            return false;
+
+        ROS_INFO("Connected to %s", m_deviceName);
+        return true;
+    }
+
+    void PcapDevice::disconnect()
+    {
+        if (!isConnected())
+            return;
+
+        pcap_close(m_device);
+        m_device = nullptr;
+        ROS_INFO("Disconnected from %s", m_deviceName);
+    }
+
+    bool PcapDevice::isConnected() const { return m_device; }
+
+    ReadResult PcapDevice::read()
+    {
+        if (!isConnected())
+            return READ_ERROR;
+
+        struct pcap_pkthdr* header;
+        const u_char* pktData;
+        int result;
+
+        result = pcap_next_ex(m_device, &header, &pktData);
+
+        if (result >= 0)
+        {
+            auto ipHdr =
+                reinterpret_cast<const iphdr*>(pktData + sizeof(struct ethhdr));
+            uint32_t ipHdrLen = ipHdr->ihl * 4u;
+
+            switch (ipHdr->protocol)
+            {
+            case 6:
+            {
+                if (header->len == 54)
+                {
+                    return READ_SUCCESS;
+                }
+                bool storePkt = true;
+
+                if (!m_lastPkt.empty())
+                {
+                    auto tcpHdr = reinterpret_cast<const tcphdr*>(
+                        pktData + ipHdrLen + sizeof(struct ethhdr));
+
+                    auto lastIpHdr = reinterpret_cast<const iphdr*>(&(m_lastPkt[0]));
+                    uint32_t lastIpHdrLen = lastIpHdr->ihl * 4u;
+                    auto lastTcpHdr = reinterpret_cast<const tcphdr*>(
+                        &(m_lastPkt[0]) + lastIpHdrLen);
+                    uint16_t lastLen =
+                        ntohs(static_cast<uint16_t>(lastIpHdr->tot_len));
+                    uint16_t newLen = ntohs(static_cast<uint16_t>(ipHdr->tot_len));
+                    uint32_t lastSeq = ntohl(lastTcpHdr->seq);
+                    uint32_t newSeq = ntohl(tcpHdr->seq);
+
+                    if (newSeq != lastSeq)
+                    {
+                        uint32_t dataOffset = lastTcpHdr->doff * 4;
+                        m_dataBuff.insert(m_dataBuff.end(),
+                                          m_lastPkt.begin() + lastIpHdrLen +
+                                              dataOffset,
+                                          m_lastPkt.end());
+                    } else if (newLen <= lastLen)
+                    {
+                        storePkt = false;
+                    }
+                }
+
+                if (storePkt)
+                {
+                    m_lastPkt.clear();
+                    m_lastPkt.insert(m_lastPkt.end(),
+                                     pktData + sizeof(struct ethhdr),
+                                     pktData + header->len);
+                }
+                break;
+            }
+
+            default:
+            {
+                ROS_ERROR("Skipping protocol: %d", result);
+                return READ_ERROR;
+            }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+            return READ_SUCCESS;
+        } else if (result == -2)
+        {
+            ROS_INFO("Done reading from %s", m_deviceName);
+            if (!m_lastPkt.empty())
+            {
+                auto lastIpHdr = reinterpret_cast<const iphdr*>(&(m_lastPkt[0]));
+                uint32_t ipHdrLength = lastIpHdr->ihl * 4u;
+
+                auto lastTcpHdr =
+                    reinterpret_cast<const tcphdr*>(&(m_lastPkt[0]) + ipHdrLength);
+                uint32_t dataOffset = lastTcpHdr->doff * 4u;
+
+                m_dataBuff.insert(m_dataBuff.end(),
+                                  m_lastPkt.begin() + ipHdrLength + dataOffset,
+                                  m_lastPkt.end());
+
+                m_lastPkt.clear();
+            }
+            disconnect();
+            return READ_SUCCESS;
+        } else
+        {
+            ROS_ERROR("Error reading data");
+            return READ_ERROR;
+        }
+    }
+} // namespace pcapReader

--- a/src/septentrio_gnss_driver/communication/rx_message.cpp
+++ b/src/septentrio_gnss_driver/communication/rx_message.cpp
@@ -1275,8 +1275,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::PVTCartesian>("/pvtcartesian",
                                                                   g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1318,8 +1318,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::PVTGeodetic>("/pvtgeodetic",
                                                                  g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1358,8 +1358,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::PosCovCartesian>(
                 "/poscovcartesian", g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1400,8 +1400,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::PosCovGeodetic>(
                 "/poscovgeodetic", g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1441,8 +1441,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::AttEuler>("/atteuler",
                                                               g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1482,8 +1482,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::AttCovEuler>("/attcoveuler",
                                                                  g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1517,8 +1517,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         msg->source = "GPST";
         static ros::Publisher publisher =
             g_nh->advertise<sensor_msgs::TimeReference>("/gpst", g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1577,8 +1577,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::Gpgga>("/gpgga",
                                                            g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time.sec = msg->header.stamp.sec;
@@ -1634,8 +1634,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::Gprmc>("/gprmc",
                                                            g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time.sec = msg->header.stamp.sec;
@@ -1696,8 +1696,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::Gpgsa>("/gpgsa",
                                                            g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time.sec = msg->header.stamp.sec;
@@ -1760,8 +1760,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<septentrio_gnss_driver::Gpgsv>("/gpgsv",
                                                            g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time.sec = msg->header.stamp.sec;
@@ -1804,8 +1804,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         g_poscovgeodetic_has_arrived_navsatfix = false;
         static ros::Publisher publisher =
             g_nh->advertise<sensor_msgs::NavSatFix>("/navsatfix", g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1858,8 +1858,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         g_attcoveuler_has_arrived_gpsfix = false;
         static ros::Publisher publisher =
             g_nh->advertise<gps_common::GPSFix>("/gpsfix", g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1905,8 +1905,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<geometry_msgs::PoseWithCovarianceStamped>(
                 "/pose", g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;
@@ -1974,8 +1974,8 @@ bool io_comm_rx::RxMessage::read(std::string message_key, bool search)
         static ros::Publisher publisher =
             g_nh->advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics",
                                                               g_ROS_QUEUE_SIZE);
-        // Wait as long as necessary (only when reading from SBF file)
-        if (g_read_from_sbf_log)
+        // Wait as long as necessary (only when reading from SBF/PCAP file)
+        if (g_read_from_sbf_log || g_read_from_pcap_log)
         {
             ros::Time unix_old = g_unix_time;
             g_unix_time = time_obj;

--- a/src/septentrio_gnss_driver/node/rosaic_node.cpp
+++ b/src/septentrio_gnss_driver/node/rosaic_node.cpp
@@ -53,7 +53,7 @@ rosaic_node::ROSaicNode::ROSaicNode()
 
     // Sends commands to the Rx regarding which SBF/NMEA messages it should output
     // and sets all its necessary corrections-related parameters
-    if (!g_read_from_sbf_log)
+    if (!g_read_from_sbf_log && !g_read_from_pcap_log)
     {
         boost::mutex::scoped_lock lock(connection_mutex_);
         connection_condition_.wait(lock, [this]() { return connected_; });
@@ -513,6 +513,7 @@ void rosaic_node::ROSaicNode::initializeIO()
 
         serial_ = false;
         g_read_from_sbf_log = false;
+        g_read_from_pcap_log = false;
         boost::thread temporary_thread(boost::bind(&ROSaicNode::connect, this));
         temporary_thread.detach();
     } else if (boost::regex_match(device_, match,
@@ -520,15 +521,31 @@ void rosaic_node::ROSaicNode::initializeIO()
     {
         serial_ = false;
         g_read_from_sbf_log = true;
+        g_read_from_pcap_log = false;
         g_unix_time.sec = 0;
         g_unix_time.nsec = 0;
         boost::thread temporary_thread(
             boost::bind(&ROSaicNode::prepareSBFFileReading, this, match[2]));
         temporary_thread.detach();
-    } else if (boost::regex_match(device_, match, boost::regex("(serial):(.+)")))
+    } else if (boost::regex_match(
+                   device_, match,
+                   boost::regex("(file_name):(/|(?:/[\\w-]+)+.pcap)")))
+    {
+        serial_ = false;
+        g_read_from_sbf_log = false;
+        g_read_from_pcap_log = true;
+        g_unix_time.sec = 0;
+        g_unix_time.nsec = 0;
+        boost::thread temporary_thread(
+            boost::bind(&ROSaicNode::preparePCAPFileReading, this, match[2]));
+        temporary_thread.detach();
+    }
+
+    else if (boost::regex_match(device_, match, boost::regex("(serial):(.+)")))
     {
         serial_ = true;
         g_read_from_sbf_log = false;
+        g_read_from_pcap_log = false;
         std::string proto(match[2]);
         std::stringstream ss;
         ss << "Searching for serial port" << proto;
@@ -556,6 +573,23 @@ void rosaic_node::ROSaicNode::prepareSBFFileReading(std::string file_name)
     {
         std::stringstream ss;
         ss << "Comm_IO::initializeSBFFileReading() failed for SBF File" << file_name
+           << " due to: " << e.what();
+        ROS_ERROR("%s", ss.str().c_str());
+    }
+}
+
+void rosaic_node::ROSaicNode::preparePCAPFileReading(std::string file_name)
+{
+    try
+    {
+        std::stringstream ss;
+        ss << "Setting up everything needed to read from " << file_name;
+        ROS_DEBUG("%s", ss.str().c_str());
+        IO.initializePCAPFileReading(file_name);
+    } catch (std::runtime_error& e)
+    {
+        std::stringstream ss;
+        ss << "CommIO::initializePCAPFileReading() failed for SBF File " << file_name
            << " due to: " << e.what();
         ROS_ERROR("%s", ss.str().c_str());
     }
@@ -855,6 +889,8 @@ bool g_qualityind_has_arrived_diagnostics;
 ros::Time g_unix_time;
 //! Whether or not we are reading from an SBF file
 bool g_read_from_sbf_log;
+//! Whether or not we are reading from a PCAP file
+bool g_read_from_pcap_log;
 //! A C++ map for keeping track of the SBF blocks necessary to construct the GPSFix
 //! ROS message
 std::map<std::string, uint32_t> g_GPSFixMap;


### PR DESCRIPTION
## Description
Driver is now able to handle pcap files as device parameters, process data and publish in ROS topics

## Dependency updates
Driver package now depends on [pcap](https://www.tcpdump.org/manpages/pcap.3pcap.html) Packet Capture library. The package README and CMakeLists.txt has been appropriately updated.

## Brief implementation details
An auxiliary class for handling PCAP files was created that writes the raw data to a specified buffer. Rest of the pipeline follows the same steps as for the SBF log file handling.

## Testing
Package compiled and tested on a Debian (stretch) based docker container running ROS Melodic using PCAP captures from the Mosaic-X5 GNSS module.