### PR TITLE
Compiled and tested on Noetic

### DIFF
--- a/config/rover.yaml
+++ b/config/rover.yaml
@@ -1,6 +1,6 @@
 # Configuration Settings for the Rover Rx
 
-device: tcp://xxx.xxx.xxx.xxx:xxxx
+device: serial:/dev/ttyACM0
 
 serial:
   baudrate: 115200

--- a/src/septentrio_gnss_driver/node/rosaic_node.cpp
+++ b/src/septentrio_gnss_driver/node/rosaic_node.cpp
@@ -498,6 +498,8 @@ void rosaic_node::ROSaicNode::initializeIO()
 {
     ROS_DEBUG("Called initializeIO() method");
     boost::smatch match;
+
+	ROS_DEBUG_STREAM("DEVICE: " << device_);
     // In fact: smatch is a typedef of match_results<string::const_iterator>
     if (boost::regex_match(device_, match, boost::regex("(tcp)://(.+):(\\d+)")))
     // C++ needs \\d instead of \d: Both mean decimal.
@@ -551,6 +553,7 @@ void rosaic_node::ROSaicNode::initializeIO()
         std::string proto(match[2]);
         std::stringstream ss;
         ss << "Searching for serial port" << proto;
+		device_ = proto;
         ROS_DEBUG("%s", ss.str().c_str());
         boost::thread temporary_thread(boost::bind(&ROSaicNode::connect, this));
         temporary_thread.detach();


### PR DESCRIPTION
I had to add a line "```device_ = proto```". Otherwise the device would still contain `serial:` and if I removed the serial part from the device parameter in the yaml file, it would not match the regex string.

Tested with the AsteRx-i3 D Pro+ on Ubuntu 20.04, ROS Noetic