### PR TITLE
fix: modify build error for rolling/humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,14 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-rosidl_target_interfaces(${library_name} ${PROJECT_NAME} "rosidl_typesupport_cpp")
+if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)
+  rosidl_target_interfaces(${library_name}
+    ${PROJECT_NAME} "rosidl_typesupport_cpp")
+else()
+  rosidl_get_typesupport_target(
+    cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+  target_link_libraries(${library_name} "${cpp_typesupport_target}")
+endif()
 
 ## executable
 add_executable(${executable_name}


### PR DESCRIPTION
I modified CMakeLists.txt to support rolling/humble distribution.
See https://docs.ros.org/en/rolling/Releases/Release-Humble-Hawksbill.html.
```
Deprecation of rosidl_target_interfaces()[](https://docs.ros.org/en/rolling/Releases/Release-Humble-Hawksbill.html#deprecation-of-rosidl-target-interfaces)
The CMake function rosidl_target_interfaces() has been deprecated, and now issues a CMake warning when called. Users wanting to use messages/services/actions in the same ROS package that generated them should instead call rosidl_get_typesupport_target() and then target_link_libraries() to make their targets depend on the returned typesupport target. See https://github.com/ros2/rosidl/pull/606 for more details, and https://github.com/ros2/demos/pull/529 for an example of using the new function.
```
