### PR TITLE
Resolve issues with removed/renamed functionality in boost 1.87

### DIFF
--- a/src/septentrio_gnss_driver/communication/communication_core.cpp
+++ b/src/septentrio_gnss_driver/communication/communication_core.cpp
@@ -172,7 +172,7 @@ namespace io {
             log_level::DEBUG,
             "Started timer for calling connect() method until connection succeeds");
 
-        boost::asio::io_service io;
+        boost::asio::io_context io;
         if (initializeIo())
         {
             initializedIo_ = manager_->connect();
@@ -308,11 +308,11 @@ namespace io {
                 send("login, " + settings_->login_user + ", " +
                      settings_->login_password + " \x0D");
         }
-        
+
         // Turning off all current SBF/NMEA output
         send("sso, all, none, none, off \x0D");
         send("sno, all, none, none, off \x0D");
-        
+
         if (!settings_->custom_commands_file.empty())
         {
             if ((std::filesystem::exists(settings_->custom_commands_file)))


### PR DESCRIPTION
This makes some quick changes to the issues described in #151 to make it build with boost 1.87. 

The places where the logging would de-reference the endpointIterator before now has a begin() added to print the first endpoint, not sure is this is the intended behavior. The other changes are find and replace for functionality that should be equivalent.