### PR TITLE
Fix regression in ROS 2 Rolling (#155)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ endif ()
 
 find_package(ament_cmake QUIET)
 find_package(catkin QUIET)
+find_package(gtest_vendor)
+find_package(ament_cmake_ros)
 
 if(catkin_FOUND)
   ## ROS 1 -----------------------------------------------------------------------------------------------  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,6 @@ endif ()
 
 find_package(ament_cmake QUIET)
 find_package(catkin QUIET)
-find_package(gtest_vendor)
-find_package(ament_cmake_ros)
 
 if(catkin_FOUND)
   ## ROS 1 -----------------------------------------------------------------------------------------------  
@@ -163,6 +161,8 @@ elseif(ament_cmake_FOUND)
   find_package(tf2_eigen REQUIRED)
   find_package(tf2_geometry_msgs REQUIRED)
   find_package(tf2_ros REQUIRED)
+  find_package(gtest_vendor REQUIRED)
+  find_package(ament_cmake_ros REQUIRED)
   
   ## Declare  messages
   rosidl_generate_interfaces(${PROJECT_NAME}

--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,9 @@
   <member_of_group condition="$ROS_VERSION == 2">rosidl_interface_packages</member_of_group>
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
   <depend condition="$ROS_VERSION == 2">rclcpp_components</depend>
-  
+  <depend condition="$ROS_VERSION == 2">ament_cmake_ros</depend>
+  <depend condition="$ROS_VERSION == 2">gtest_vendor</depend>
+
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
   <depend condition="$ROS_VERSION == 1">roscpp</depend>
@@ -49,9 +51,6 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>ament_cmake_ros</depend>
-  <depend>gtest_vendor</depend>
-
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -49,6 +49,8 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>ament_cmake_ros</depend>
+  <depend>gtest_vendor</depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>


### PR DESCRIPTION
Explicitly add ament_cmake_gtest to fix ROS 2 Rolling buildfarm error. Fixes #155.